### PR TITLE
[40]  Http response fingerprinting support

### DIFF
--- a/examples/p0f.rs
+++ b/examples/p0f.rs
@@ -84,5 +84,8 @@ fn main() {
         if let Some(http_request) = output.http_request {
             info!("{}", http_request);
         }
+        if let Some(http_response) = output.http_response {
+            info!("{}", http_response);
+        }
     }
 }

--- a/src/http_process.rs
+++ b/src/http_process.rs
@@ -15,16 +15,56 @@ use ttl_cache::TtlCache;
 /// FlowKey: (Client IP, Server IP, Client Port, Server Port)
 pub type FlowKey = (IpAddr, IpAddr, u16, u16);
 
+#[derive(Clone)]
+struct TcpData {
+    sequence: u32,
+    data: Vec<u8>,
+}
+
 pub struct TcpFlow {
     client_ip: IpAddr,
     server_ip: IpAddr,
     client_port: u16,
     server_port: u16,
-    client_seq: u32,
-    server_seq: u32,
-    client_data: Vec<u8>, // Aggregated HTTP request payload
-    server_data: Vec<u8>, // Aggregated HTTP response payload
-    last_seen: Instant,   // Timestamp for flow expiration
+    client_data: Vec<TcpData>,
+    server_data: Vec<TcpData>,
+    last_seen: Instant, // Timestamp for flow expiration
+}
+impl TcpFlow {
+    fn apply(src_ip: IpAddr, src_port: u16, dst_ip: IpAddr, dst_port: u16) -> TcpFlow {
+        TcpFlow {
+            client_ip: src_ip,
+            server_ip: dst_ip,
+            client_port: src_port,
+            server_port: dst_port,
+            //client_seq: tcp.get_sequence(),
+            //server_seq: 0,
+            client_data: Vec::new(),
+            server_data: Vec::new(),
+            last_seen: Instant::now(),
+        }
+    }
+    /// Traversing all the data in sequence in the correct order to build the full data
+    ///
+    /// # Parameters
+    /// - `is_client`: If the data comes from the client.
+    fn get_full_data(&self, is_client: bool) -> Vec<u8> {
+        let data = if is_client {
+            &self.client_data
+        } else {
+            &self.server_data
+        };
+
+        let mut sorted_data = data.clone();
+
+        sorted_data.sort_by_key(|tcp_data| tcp_data.sequence);
+
+        let mut full_data = Vec::new();
+        for tcp_data in sorted_data {
+            full_data.extend_from_slice(&tcp_data.data);
+        }
+        full_data
+    }
 }
 
 pub fn process_http_ipv4(
@@ -77,46 +117,40 @@ fn process_tcp_packet(
     src_ip: IpAddr,
     dst_ip: IpAddr,
 ) -> Result<ObservableHttpPackage, Error> {
-    let src_port = tcp.get_source();
-    let dst_port = tcp.get_destination();
-    let flow_key = (src_ip, dst_ip, src_port, dst_port);
+    let src_port: u16 = tcp.get_source();
+    let dst_port: u16 = tcp.get_destination();
+    let flow_key: FlowKey = (src_ip, dst_ip, src_port, dst_port);
     let mut http_request: Option<ObservableHttpRequest> = None;
     let mut http_response: Option<ObservableHttpResponse> = None;
 
     if tcp.get_flags() & pnet::packet::tcp::TcpFlags::SYN != 0 {
-        let flow = TcpFlow {
-            client_ip: src_ip,
-            server_ip: dst_ip,
-            client_port: src_port,
-            server_port: dst_port,
-            client_seq: tcp.get_sequence(),
-            server_seq: 0,
-            client_data: Vec::new(),
-            server_data: Vec::new(),
-            last_seen: Instant::now(),
-        };
+        let flow: TcpFlow = TcpFlow::apply(src_ip, src_port, dst_ip, dst_port);
         cache.insert(flow_key, flow, Duration::new(60, 0));
-        return Ok(ObservableHttpPackage {
-            http_request: None,
-            http_response: None,
-        });
     }
 
+    // TODO: WIP
     if let Some(flow) = cache.get_mut(&flow_key) {
-        flow.last_seen = Instant::now();
+        flow.last_seen = Instant::now(); // TODO: WIP
 
         if !tcp.payload().is_empty() {
-            // Append the new data to the flow data
             if src_ip == flow.client_ip && src_port == flow.client_port {
-                flow.client_data.extend_from_slice(tcp.payload());
-                if let Ok(http_request_parsed) = parse_http_request(&flow.client_data) {
+                let tcp_data: TcpData = TcpData {
+                    sequence: tcp.get_sequence(),
+                    data: Vec::from(tcp.payload()),
+                };
+                flow.client_data.push(tcp_data);
+                if let Ok(http_request_parsed) = parse_http_request(&flow.get_full_data(true)) {
                     http_request = http_request_parsed;
                 }
-            } else {
-                flow.server_data.extend_from_slice(tcp.payload());
-                /*if let Ok(response) = parse_http_response(&flow.server_data) {
-                    info!("HTTP Response:\n{:?}", response);
-                }*/
+            } else if src_ip == flow.server_ip && src_port == flow.server_port {
+                let tcp_data: TcpData = TcpData {
+                    sequence: tcp.get_sequence(),
+                    data: Vec::from(tcp.payload()),
+                };
+                flow.server_data.push(tcp_data);
+                if let Ok(http_response_parsed) = parse_http_response(&flow.get_full_data(false)) {
+                    http_response = http_response_parsed;
+                }
             }
         }
 
@@ -147,13 +181,9 @@ fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, Erro
                 .collect();
 
             let headers_in_order: Vec<Header> = build_headers_in_order(&headers);
-
             let headers_absent: Vec<Header> = build_headers_absent_in_order(&headers);
-
             let user_agent: Option<String> = extract_user_agent(&headers);
-
             let lang: Option<String> = extract_accept_language(&headers);
-
             let http_version: Version = extract_http_version(req);
 
             Ok(Some(ObservableHttpRequest {
@@ -182,6 +212,11 @@ fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, Erro
             )))
         }
     }
+}
+
+fn parse_http_response(_data: &[u8]) -> Result<Option<ObservableHttpResponse>, Error> {
+    // TODO: WIP
+    Ok(None)
 }
 
 fn build_headers_in_order(headers: &[Header]) -> Vec<Header> {

--- a/src/p0f_output.rs
+++ b/src/p0f_output.rs
@@ -203,7 +203,7 @@ impl fmt::Display for HttpResponseOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            ".-[ {}/{} -> {}/{} (http request) ]-\n\
+            ".-[ {}/{} -> {}/{} (http response) ]-\n\
             |\n\
             | server   = {}\n\
             | app      = {}\n\

--- a/src/p0f_output.rs
+++ b/src/p0f_output.rs
@@ -3,6 +3,7 @@ use crate::http;
 use crate::process::IpPort;
 use crate::tcp::{Signature, Ttl};
 use std::fmt;
+use std::fmt::Formatter;
 
 pub struct P0fOutput {
     pub syn: Option<SynTCPOutput>,
@@ -10,6 +11,7 @@ pub struct P0fOutput {
     pub mtu: Option<MTUOutput>,
     pub uptime: Option<UptimeOutput>,
     pub http_request: Option<HttpRequestOutput>,
+    pub http_response: Option<HttpResponseOutput>,
 }
 
 pub struct SynTCPOutput {
@@ -27,7 +29,7 @@ pub struct SynAckTCPOutput {
 }
 
 impl fmt::Display for SynTCPOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             ".-[ {}/{} -> {}/{} (syn) ]-\n\
@@ -60,7 +62,7 @@ impl fmt::Display for SynTCPOutput {
 }
 
 impl fmt::Display for SynAckTCPOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             ".-[ {}/{} -> {}/{} (syn+ack) ]-\n\
@@ -100,7 +102,7 @@ pub struct MTUOutput {
 }
 
 impl fmt::Display for MTUOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             ".-[ {}/{} -> {}/{} (mtu) ]-\n\
@@ -131,7 +133,7 @@ pub struct UptimeOutput {
 }
 
 impl fmt::Display for UptimeOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             ".-[ {}/{} -> {}/{} (uptime) ]-\n\
@@ -164,7 +166,7 @@ pub struct HttpRequestOutput {
 }
 
 impl fmt::Display for HttpRequestOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             ".-[ {}/{} -> {}/{} (http request) ]-\n\
@@ -182,6 +184,40 @@ impl fmt::Display for HttpRequestOutput {
             self.source.ip,
             self.user_agent.as_deref().unwrap_or("???"),
             self.lang.as_deref().unwrap_or("???"),
+            self.label
+                .as_ref()
+                .map_or("none".to_string(), |l| l.ty.to_string()),
+            self.sig,
+        )
+    }
+}
+
+pub struct HttpResponseOutput {
+    pub source: IpPort,
+    pub destination: IpPort,
+    pub label: Option<Label>,
+    pub sig: http::Signature,
+}
+
+impl fmt::Display for HttpResponseOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            ".-[ {}/{} -> {}/{} (http request) ]-\n\
+            |\n\
+            | server   = {}\n\
+            | app      = {}\n\
+            | params   = {}\n\
+            | raw_sig  = {}\n\
+            `----\n",
+            self.source.ip,
+            self.source.port,
+            self.destination.ip,
+            self.destination.port,
+            self.source.ip,
+            self.label
+                .as_ref()
+                .map_or("???".to_string(), |l| l.name.clone()),
             self.label
                 .as_ref()
                 .map_or("none".to_string(), |l| l.ty.to_string()),

--- a/src/p0f_output.rs
+++ b/src/p0f_output.rs
@@ -73,12 +73,12 @@ impl fmt::Display for SynAckTCPOutput {
             | params   = {}\n\
             | raw_sig  = {}\n\
             `----\n",
+            self.source.ip,
+            self.source.port,
             self.destination.ip,
             self.destination.port,
-            self.source.ip,
-            self.source.port,
-            self.source.ip,
-            self.source.port,
+            self.destination.ip,
+            self.destination.port,
             self.label.as_ref().map_or("???".to_string(), |l| {
                 format!("{}/{}", l.name, l.flavor.as_deref().unwrap_or("???"))
             }),
@@ -107,7 +107,7 @@ impl fmt::Display for MTUOutput {
             f,
             ".-[ {}/{} -> {}/{} (mtu) ]-\n\
             |\n\
-            | client   = {}\n\
+            | server   = {}/{}\n\
             | link     = {}\n\
             | raw_mtu  = {}\n\
             `----\n",
@@ -115,7 +115,8 @@ impl fmt::Display for MTUOutput {
             self.source.port,
             self.destination.ip,
             self.destination.port,
-            self.source.ip,
+            self.destination.ip,
+            self.destination.port,
             self.link,
             self.mtu,
         )
@@ -138,7 +139,7 @@ impl fmt::Display for UptimeOutput {
             f,
             ".-[ {}/{} -> {}/{} (uptime) ]-\n\
             |\n\
-            | client   = {}\n\
+            | client   = {}/{}\n\
             | uptime   = {} days, {} hrs, {} min (modulo {} days)\n\
             | raw_freq = {} Hz\n\
             `----\n",
@@ -147,6 +148,7 @@ impl fmt::Display for UptimeOutput {
             self.destination.ip,
             self.destination.port,
             self.source.ip,
+            self.source.port,
             self.days,
             self.hours,
             self.min,
@@ -171,7 +173,7 @@ impl fmt::Display for HttpRequestOutput {
             f,
             ".-[ {}/{} -> {}/{} (http request) ]-\n\
             |\n\
-            | client   = {}\n\
+            | client   = {}/{}\n\
             | app      = {}\n\
             | lang     = {}\n\
             | params   = {}\n\
@@ -182,6 +184,7 @@ impl fmt::Display for HttpRequestOutput {
             self.destination.ip,
             self.destination.port,
             self.source.ip,
+            self.source.port,
             self.user_agent.as_deref().unwrap_or("???"),
             self.lang.as_deref().unwrap_or("???"),
             self.label
@@ -205,7 +208,7 @@ impl fmt::Display for HttpResponseOutput {
             f,
             ".-[ {}/{} -> {}/{} (http response) ]-\n\
             |\n\
-            | server   = {}\n\
+            | server   = {}/{}\n\
             | app      = {}\n\
             | params   = {}\n\
             | raw_sig  = {}\n\
@@ -214,7 +217,8 @@ impl fmt::Display for HttpResponseOutput {
             self.source.port,
             self.destination.ip,
             self.destination.port,
-            self.source.ip,
+            self.destination.ip,
+            self.destination.port,
             self.label
                 .as_ref()
                 .map_or("???".to_string(), |l| l.name.clone()),

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,6 @@
-use crate::http_process::{FlowKey, ObservableHttpPackage, ObservableHttpRequest, TcpFlow};
+use crate::http_process::{
+    FlowKey, ObservableHttpPackage, ObservableHttpRequest, ObservableHttpResponse, TcpFlow,
+};
 use crate::mtu::ObservableMtu;
 use crate::tcp_process::{ObservableTCPPackage, ObservableTcp};
 use crate::uptime::ObservableUptime;
@@ -30,6 +32,7 @@ pub struct ObservablePackage {
     pub mtu: Option<ObservableMtu>,
     pub uptime: Option<ObservableUptime>,
     pub http_request: Option<ObservableHttpRequest>,
+    pub http_response: Option<ObservableHttpResponse>,
 }
 
 impl ObservablePackage {
@@ -132,6 +135,7 @@ fn handle_http_tcp_responses(
             mtu: tcp_package.mtu,
             uptime: tcp_package.uptime,
             http_request: http_package.http_request,
+            http_response: http_package.http_response,
         }),
         (Err(http_err), _) => Err(http_err),
         (_, Err(tcp_err)) => Err(tcp_err),


### PR DESCRIPTION
# Pull Request Template

## Description

p0f’s official documentation emphasizes the importance of collecting HTTP response signatures to detect different types of servers and their configurations. This is achieved by analyzing HTTP response headers, such as Server, Date, X-Cache-Status, and Connection. These headers often contain details that can reveal server software (e.g., nginx, Apache), version numbers, and additional metadata (e.g., caching mechanisms, server configuration).

