### PR TITLE
Dynamically Evaluate TTL Behavior Based on Observed Values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod process;
 mod signature_matcher;
 mod tcp;
 mod tcp_process;
+mod ttl;
 mod uptime;
 
 use crate::db::{Database, Label};

--- a/src/p0f_output.rs
+++ b/src/p0f_output.rs
@@ -85,7 +85,9 @@ impl fmt::Display for SynAckTCPOutput {
             }),
             match self.sig.ittl {
                 Ttl::Distance(_, distance) => distance,
-                _ => "Unknown".parse().unwrap(),
+                Ttl::Bad(value) => value,
+                Ttl::Value(value) => value,
+                Ttl::Guess(value) => value,
             },
             self.label
                 .as_ref()

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -50,10 +50,10 @@ impl IpVersion {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Ttl {
-    Value(u8),
-    Distance(u8, u8),
-    Guess(u8),
-    Bad(u8),
+    Value(u8),        // Raw TTL value (when we don't have enough information)
+    Distance(u8, u8), // TTL value and estimated number of hops (distance)
+    Guess(u8),        // Guessed TTL value (when it's uncertain)
+    Bad(u8),          // Invalid TTL value (e.g., TTL is 0)
 }
 
 impl Ttl {

--- a/src/tcp_process.rs
+++ b/src/tcp_process.rs
@@ -1,10 +1,10 @@
-use crate::mtu;
 use crate::mtu::ObservableMtu;
 use crate::process::IpPort;
 use crate::tcp;
 use crate::tcp::{IpVersion, PayloadSize, Quirk, TcpOption, Ttl, WindowSize};
 use crate::uptime::{check_ts_tcp, ObservableUptime};
 use crate::uptime::{Connection, SynData};
+use crate::{mtu, ttl};
 use failure::{bail, err_msg, Error};
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::{
@@ -58,7 +58,7 @@ pub fn process_tcp_ipv4(
 
     let version = IpVersion::V4;
     let ttl_observed: u8 = packet.get_ttl();
-    let ttl: Ttl = calculate_ttl(ttl_observed);
+    let ttl: Ttl = ttl::calculate_ttl(ttl_observed);
     let olen: u8 = packet.get_options_raw().len() as u8;
     let mut quirks = vec![];
 
@@ -113,7 +113,7 @@ pub fn process_tcp_ipv6(
     }
     let version = IpVersion::V6;
     let ttl_observed: u8 = packet.get_hop_limit();
-    let ttl: Ttl = calculate_ttl(ttl_observed);
+    let ttl: Ttl = ttl::calculate_ttl(ttl_observed);
     let olen = 0; // TODO handle extensions
     let mut quirks = vec![];
 
@@ -144,54 +144,6 @@ pub fn process_tcp_ipv6(
                 destination_ip,
             )
         })
-}
-
-fn guess_distance(ttl: u8) -> u8 {
-    if ttl <= 32 {
-        32 - ttl
-    } else if ttl <= 64 {
-        64 - ttl
-    } else if ttl <= 128 {
-        128 - ttl
-    } else {
-        255 - ttl
-    }
-}
-
-fn calculate_ttl(ttl_observed: u8) -> Ttl {
-    // TODO: WIP
-    // Known TTL initial values from common OSes
-    const TTL_WINDOWS: u8 = 128; // Windows typically uses 128
-    const TTL_LINUX: u8 = 64; // Linux typically uses 64
-    const TTL_OSX: u8 = 64; // macOS typically uses 64
-    const TTL_IOS: u8 = 64; // iOS typically uses 64
-    const TTL_ANDROID: u8 = 64; // Android typically uses 64
-    const TTL_FREEBSD: u8 = 255; // FreeBSD typically uses 255
-
-    if ttl_observed == 0 {
-        return Ttl::Bad(ttl_observed); // Bad TTL value
-    }
-
-    // Known TTL initial values (this could be extended with more OSes)
-    let common_initial_ttl_list = [
-        TTL_WINDOWS,
-        TTL_LINUX,
-        TTL_OSX,
-        TTL_IOS,
-        TTL_ANDROID,
-        TTL_FREEBSD,
-    ];
-
-    // Check if ttl_observed matches any known initial TTL value
-    if let Some(&_initial_ttl) = common_initial_ttl_list
-        .iter()
-        .find(|&&initial| ttl_observed == initial)
-    {
-        return Ttl::Distance(ttl_observed, guess_distance(ttl_observed));
-    }
-
-    // If TTL doesn't match common initial values, classify it as Ttl::Value (raw TTL)
-    Ttl::Value(ttl_observed)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -403,38 +355,4 @@ fn visit_tcp(
             port: destination_port,
         },
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_guess_distance() {
-        assert_eq!(guess_distance(32), 0);
-        assert_eq!(guess_distance(64), 0);
-        assert_eq!(guess_distance(128), 0);
-        assert_eq!(guess_distance(200), 55);
-        assert_eq!(guess_distance(255), 0);
-    }
-
-    #[test]
-    fn test_calculate_bad_ttl() {
-        assert_eq!(calculate_ttl(0), Ttl::Bad(0));
-    }
-
-    #[test]
-    fn test_calculate_distance_ttl() {
-        assert_eq!(calculate_ttl(64), Ttl::Distance(64, 0));
-        assert_eq!(calculate_ttl(128), Ttl::Distance(128, 0));
-        assert_eq!(calculate_ttl(255), Ttl::Distance(255, 0));
-    }
-
-    #[test]
-    fn test_calculate_not_match_known_pattern_ttl() {
-        assert_eq!(calculate_ttl(20), Ttl::Value(20));
-        assert_eq!(calculate_ttl(32), Ttl::Value(32));
-        assert_eq!(calculate_ttl(150), Ttl::Value(150));
-        assert_eq!(calculate_ttl(200), Ttl::Value(200));
-    }
 }

--- a/src/ttl.rs
+++ b/src/ttl.rs
@@ -1,0 +1,74 @@
+use crate::tcp::Ttl;
+
+fn guess_distance(ttl: u8) -> u8 {
+    if ttl <= 32 {
+        32 - ttl
+    } else if ttl <= 64 {
+        64 - ttl
+    } else if ttl <= 128 {
+        128 - ttl
+    } else {
+        255 - ttl
+    }
+}
+
+/// Calculate TTL using the Known TTL values from common OSes
+/// TTL_WINDOWS: u8 = 128; // Windows typically uses 128
+/// TTL_LINUX: u8 = 64; // Linux typically uses 64
+/// TTL_OSX: u8 = 64; // macOS typically uses 64
+/// TTL_IOS: u8 = 64; // iOS typically uses 64
+/// TTL_ANDROID: u8 = 64; // Android typically uses 64
+/// TTL_FREEBSD: u8 = 255; // FreeBSD typically uses 255
+pub fn calculate_ttl(ttl_observed: u8) -> Ttl {
+    if ttl_observed == 0 {
+        return Ttl::Bad(ttl_observed); // Bad TTL value
+    }
+
+    // Known TTL initial values (this could be extended with more OSes)
+    let common_initial_ttl_list = &[64, 128, 255];
+
+    // Check if ttl_observed matches any known initial TTL value
+    if let Some(&_initial_ttl) = common_initial_ttl_list
+        .iter()
+        .find(|&&initial| ttl_observed == initial)
+    {
+        return Ttl::Distance(ttl_observed, guess_distance(ttl_observed));
+    }
+
+    // If TTL doesn't match common initial values, classify it as Ttl::Value (raw TTL)
+    Ttl::Value(ttl_observed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_guess_distance() {
+        assert_eq!(guess_distance(32), 0);
+        assert_eq!(guess_distance(64), 0);
+        assert_eq!(guess_distance(128), 0);
+        assert_eq!(guess_distance(200), 55);
+        assert_eq!(guess_distance(255), 0);
+    }
+
+    #[test]
+    fn test_calculate_bad_ttl() {
+        assert_eq!(calculate_ttl(0), Ttl::Bad(0));
+    }
+
+    #[test]
+    fn test_calculate_distance_ttl() {
+        assert_eq!(calculate_ttl(64), Ttl::Distance(64, 0));
+        assert_eq!(calculate_ttl(128), Ttl::Distance(128, 0));
+        assert_eq!(calculate_ttl(255), Ttl::Distance(255, 0));
+    }
+
+    #[test]
+    fn test_calculate_not_match_known_pattern_ttl() {
+        assert_eq!(calculate_ttl(20), Ttl::Value(20));
+        assert_eq!(calculate_ttl(32), Ttl::Value(32));
+        assert_eq!(calculate_ttl(150), Ttl::Value(150));
+        assert_eq!(calculate_ttl(200), Ttl::Value(200));
+    }
+}


### PR DESCRIPTION
## Description

The current implementation of TTL (Time-to-Live) always uses the Ttl::Distance variant, regardless of the observed TTL value. This approach is inflexible because TTL behavior can vary depending on the context, observed value, and common defaults used by operating systems or network devices.

We need a more dynamic evaluation of TTL to improve accuracy, allowing it to categorize TTL values into appropriate variants such as Ttl::Value, Ttl::Distance, or Ttl::Bad.
