### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -34,6 +37,9 @@ jobs:
         run: cargo clippy -- -D warnings
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     container:
       image: xd009642/tarpaulin:develop-nightly
       options: --security-opt seccomp=unconfined


### PR DESCRIPTION
Potential fix for [https://github.com/biandratti/passivetcp-rs/security/code-scanning/5](https://github.com/biandratti/passivetcp-rs/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. At the root level, we will set `contents: read` as the default permission for all jobs, as this is sufficient for most CI workflows. For the `test` job, which uploads coverage reports to Codecov, we will explicitly add `contents: read` and `id-token: write` permissions, as the `codecov-action` requires these permissions to authenticate and upload reports securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
