### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,8 @@
 name: Security audit
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/biandratti/passivetcp-rs/security/code-scanning/1](https://github.com/biandratti/passivetcp-rs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow is performing a security audit and does not need write access, we will set `contents: read`. This ensures the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
