### PR TITLE
Unified Abstractions for OS, Browser, and Web Server Fingerprinting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ use crate::db::{Database, Label};
 use crate::http::{HttpDiagnosis, Signature};
 use crate::http_process::{FlowKey, TcpFlow};
 use crate::p0f_output::{
-    HttpRequestOutput, HttpResponseOutput, MTUOutput, P0fOutput, SynAckTCPOutput, SynTCPOutput,
-    UptimeOutput,
+    HttpRequestOutput, HttpResponseOutput, MTUOutput, OSQualityMatched, OperativeSystem, P0fOutput,
+    SynAckTCPOutput, SynTCPOutput, UptimeOutput,
 };
 use crate::process::ObservablePackage;
 use crate::signature_matcher::SignatureMatcher;
@@ -153,11 +153,11 @@ impl<'a> P0f<'a> {
                             .map(|observable_tcp| SynTCPOutput {
                                 source: observable_package.source.clone(),
                                 destination: observable_package.destination.clone(),
-                                matched_label: self
+                                os_matched: self
                                     .matcher
                                     .matching_by_tcp_request(&observable_tcp.signature)
-                                    .map(|(label, _signature, quality)| MatchedLabel {
-                                        label: label.clone(),
+                                    .map(|(label, _signature, quality)| OSQualityMatched {
+                                        os: OperativeSystem::from(label),
                                         quality,
                                     }),
                                 sig: observable_tcp.signature,
@@ -169,11 +169,11 @@ impl<'a> P0f<'a> {
                             .map(|observable_tcp| SynAckTCPOutput {
                                 source: observable_package.source.clone(),
                                 destination: observable_package.destination.clone(),
-                                matched_label: self
+                                os_matched: self
                                     .matcher
                                     .matching_by_tcp_request(&observable_tcp.signature)
-                                    .map(|(label, _signature, quality)| MatchedLabel {
-                                        label: label.clone(),
+                                    .map(|(label, _signature, quality)| OSQualityMatched {
+                                        os: OperativeSystem::from(label),
                                         quality,
                                     }),
                                 sig: observable_tcp.signature,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,14 @@ use crate::db::{Database, Label};
 use crate::http::{HttpDiagnosis, Signature};
 use crate::http_process::{FlowKey, TcpFlow};
 use crate::p0f_output::{
-    HttpRequestOutput, HttpResponseOutput, MTUOutput, OSQualityMatched, OperativeSystem, P0fOutput,
-    SynAckTCPOutput, SynTCPOutput, UptimeOutput,
+    Browser, BrowserQualityMatched, HttpRequestOutput, HttpResponseOutput, MTUOutput,
+    OSQualityMatched, OperativeSystem, P0fOutput, SynAckTCPOutput, SynTCPOutput, UptimeOutput,
+    WebServer, WebServerQualityMatched,
 };
 use crate::process::ObservablePackage;
 use crate::signature_matcher::SignatureMatcher;
 use crate::uptime::{Connection, SynData};
 use log::{debug, error};
-use p0f_output::MatchedLabel;
 use pnet::datalink;
 use pnet::datalink::Config;
 use std::sync::mpsc::Sender;
@@ -211,9 +211,9 @@ impl<'a> P0f<'a> {
                                 source: observable_package.source.clone(),
                                 destination: observable_package.destination.clone(),
                                 lang: http_request.lang,
-                                matched_label: signature_matcher.map(
-                                    |(label, _signature, quality)| MatchedLabel {
-                                        label: label.clone(),
+                                browser_matched: signature_matcher.map(
+                                    |(label, _signature, quality)| BrowserQualityMatched {
+                                        browser: Browser::from(label),
                                         quality,
                                     },
                                 ),
@@ -227,11 +227,11 @@ impl<'a> P0f<'a> {
                         .map(|http_response| HttpResponseOutput {
                             source: observable_package.source.clone(),
                             destination: observable_package.destination.clone(),
-                            matched_label: self
+                            web_server_matched: self
                                 .matcher
                                 .matching_by_http_response(&http_response.signature)
-                                .map(|(label, _signature, quality)| MatchedLabel {
-                                    label: label.clone(),
+                                .map(|(label, _signature, quality)| WebServerQualityMatched {
+                                    web_server: WebServer::from(label),
                                     quality,
                                 }),
                             diagnosis: HttpDiagnosis::None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,16 @@ use crate::db::{Database, Label};
 use crate::http::{HttpDiagnosis, Signature};
 use crate::http_process::{FlowKey, TcpFlow};
 use crate::p0f_output::{
-    Browser, BrowserQualityMatched, HttpRequestOutput, HttpResponseOutput, MTUOutput,
-    OSQualityMatched, OperativeSystem, P0fOutput, SynAckTCPOutput, SynTCPOutput, UptimeOutput,
-    WebServer, WebServerQualityMatched,
+    Browser, HttpRequestOutput, HttpResponseOutput, MTUOutput, OperativeSystem, P0fOutput,
+    SynAckTCPOutput, SynTCPOutput, UptimeOutput, WebServer,
 };
 use crate::process::ObservablePackage;
 use crate::signature_matcher::SignatureMatcher;
 use crate::uptime::{Connection, SynData};
 use log::{debug, error};
+use p0f_output::BrowserQualityMatched;
+use p0f_output::OSQualityMatched;
+use p0f_output::WebServerQualityMatched;
 use pnet::datalink;
 use pnet::datalink::Config;
 use std::sync::mpsc::Sender;

--- a/src/p0f_output.rs
+++ b/src/p0f_output.rs
@@ -263,7 +263,8 @@ pub struct BrowserQualityMatched {
 ///
 /// This struct contains the name, family, variant, and kind of browser.
 /// Examples:
-// TODO: Check possible values for family and variant
+/// - name: "", family: "chrome", variant: "11.x to 26.x", kind: Type::Specified
+/// - name: "", family: "firefox", variant: "3.x", kind: Type::Specified
 pub struct Browser {
     pub name: String,
     pub family: Option<String>,
@@ -346,7 +347,8 @@ pub struct WebServerQualityMatched {
 ///
 /// This struct contains the name, family, variant, and kind of browser.
 /// Examples:
-// TODO: Check possible values for family and variant
+/// - name: "", family: "apache", variant: "2.x", kind: Type::Specified
+/// - name: "", family: "nginx", variant: "1.x", kind: Type::Specified
 pub struct WebServer {
     pub name: String,
     pub family: Option<String>,

--- a/src/p0f_output.rs
+++ b/src/p0f_output.rs
@@ -33,6 +33,10 @@ pub struct P0fOutput {
 /// Represents an operative system.
 ///
 /// This struct contains the name, family, variant, and kind of operative system.
+/// Examples:
+/// - name: "Linux", family: "unix", variant: "2.2.x-3.x", kind: Type::Specified
+/// - name: "Windows", family: "win", variant: "NT kernel 6.x", kind: Type::Specified
+/// - name: "iOS", family: "unix", variant: "iPhone or iPad", kind: Type::Specified
 pub struct OperativeSystem {
     pub name: String,
     pub family: Option<String>,


### PR DESCRIPTION
The goal was to extended the passive TCP fingerprinting library to provide strong, explicit types for the three main classes of software fingerprinted by the engine:

- Operating System (OperativeSystem)
- Browser (Browser)
- Web Server (WebServer)

**What was done**
Introduced dedicated structs for each entity:
- OperativeSystem for operating system fingerprints (e.g., Linux, Windows, iOS).
- Browser for HTTP client applications (e.g., Chrome, Firefox, curl).
- WebServer for HTTP server software (e.g., nginx, Apache, IIS).
