### PR TITLE
Migrate from failure to thiserror for Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .idea/
 cobertura.xml
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,21 +98,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
 
 [[package]]
 name = "bitflags"
@@ -247,7 +217,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -407,28 +377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,12 +392,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -646,7 +588,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.65",
  "thread-id",
  "typemap-ors",
  "winapi",
@@ -657,15 +599,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
-dependencies = [
- "adler2",
-]
 
 [[package]]
 name = "no-std-net"
@@ -689,15 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.36.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -751,7 +675,6 @@ dependencies = [
  "clap",
  "criterion",
  "crossbeam",
- "failure",
  "httparse",
  "lazy_static",
  "log",
@@ -759,6 +682,7 @@ dependencies = [
  "nom",
  "pcap-file",
  "pnet",
+ "thiserror 2.0.12",
  "ttl_cache",
 ]
 
@@ -771,7 +695,7 @@ dependencies = [
  "byteorder_slice",
  "derive-into-owned",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -847,7 +771,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -904,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1009,12 +933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +980,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1121,25 +1039,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1148,7 +1054,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1159,7 +1074,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1205,12 +1131,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-any-ors"
@@ -1270,7 +1190,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1292,7 +1212,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1444,5 +1364,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.101",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,21 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,28 +67,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
-
-[[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -133,31 +100,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cc"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets",
-]
 
 [[package]]
 name = "ciborium"
@@ -231,12 +177,6 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -337,14 +277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "deranged"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "powerfmt",
 ]
 
 [[package]]
@@ -359,39 +297,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "destructure_traitobject"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "glob"
@@ -410,12 +319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,45 +335,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "ipnetwork"
@@ -542,56 +406,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-dependencies = [
- "serde",
-]
 
 [[package]]
-name = "log-mdc"
+name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-
-[[package]]
-name = "log4rs"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derivative",
- "fnv",
- "humantime",
- "libc",
- "log",
- "log-mdc",
- "once_cell",
- "parking_lot",
- "rand",
- "serde",
- "serde-value",
- "serde_json",
- "serde_yaml",
- "thiserror 1.0.65",
- "thread-id",
- "typemap-ors",
- "winapi",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -616,6 +442,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,36 +479,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
+name = "overload"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "passivetcp-rs"
@@ -677,12 +493,13 @@ dependencies = [
  "crossbeam",
  "httparse",
  "lazy_static",
- "log",
- "log4rs",
  "nom",
  "pcap-file",
  "pnet",
  "thiserror 2.0.12",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "ttl_cache",
 ]
 
@@ -697,6 +514,12 @@ dependencies = [
  "once_cell",
  "thiserror 1.0.65",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -818,13 +641,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -842,36 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -895,15 +685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,8 +692,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -923,8 +713,14 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -948,28 +744,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -996,23 +776,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "sharded-slab"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -1089,13 +859,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "4.2.2"
+name = "thread_local"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "libc",
- "winapi",
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1109,6 +910,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.65",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "ttl_cache"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,40 +992,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
-dependencies = [
- "unsafe-any-ors",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unsafe-any-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
-dependencies = [
- "destructure_traitobject",
-]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"
@@ -1162,12 +1018,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1265,15 +1115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,24 +1186,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ categories = ["network-programming"]
 [dependencies]
 nom = "8.0.0"
 pnet = "0.35.0"
-failure = "0.1.8"
+thiserror = "2.0.12"
 log = "0.4.27"
+#tracing = "0.1"
+#tracing-subscriber = "0.3"
 ttl_cache = "0.5.1"
 lazy_static = "1.5.0"
 httparse = "1.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ categories = ["network-programming"]
 nom = "8.0.0"
 pnet = "0.35.0"
 thiserror = "2.0.12"
-log = "0.4.27"
-#tracing = "0.1"
-#tracing-subscriber = "0.3"
+tracing = "0.1.41"
 ttl_cache = "0.5.1"
 lazy_static = "1.5.0"
 httparse = "1.10.1"
@@ -24,7 +22,8 @@ crossbeam = "0.8.4"
 
 [dev-dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
-log4rs = "1.3.0"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-appender = "0.2.3"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 pcap-file = "3.0.0-rc1"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use crate::{http, tcp};
-use log::error;
 use std::fmt;
+use tracing::error;
 
 /// Represents the database used by `P0f` to store signatures and associated metadata.
 /// The database contains signatures for analyzing TCP and HTTP traffic, as well as

--- a/src/db_parse.rs
+++ b/src/db_parse.rs
@@ -7,7 +7,6 @@ use crate::{
     http::{Header as HttpHeader, Signature as HttpSignature, Version as HttpVersion},
     tcp::{IpVersion, PayloadSize, Quirk, Signature as TcpSignature, TcpOption, Ttl, WindowSize},
 };
-use log::{trace, warn};
 use nom::branch::alt;
 use nom::bytes::complete::{take_until, take_while};
 use nom::character::complete::{alpha1, char, digit1};
@@ -22,6 +21,7 @@ use nom::{
     sequence::preceded,
     IResult,
 };
+use tracing::{trace, warn};
 
 impl FromStr for Database {
     type Err = TcpProcessError;

--- a/src/db_parse.rs
+++ b/src/db_parse.rs
@@ -1,12 +1,12 @@
 use std::str::FromStr;
 
 use crate::db::{Label, Type};
+use crate::error::TcpProcessError;
 use crate::{
     db::Database,
     http::{Header as HttpHeader, Signature as HttpSignature, Version as HttpVersion},
     tcp::{IpVersion, PayloadSize, Quirk, Signature as TcpSignature, TcpOption, Ttl, WindowSize},
 };
-use failure::{bail, format_err, Error};
 use log::{trace, warn};
 use nom::branch::alt;
 use nom::bytes::complete::{take_until, take_while};
@@ -24,7 +24,7 @@ use nom::{
 };
 
 impl FromStr for Database {
-    type Err = Error;
+    type Err = TcpProcessError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut classes = vec![];
@@ -46,24 +46,40 @@ impl FromStr for Database {
             if line.starts_with("classes") {
                 classes.append(
                     &mut parse_classes(line)
-                        .map_err(|err| format_err!("fail to parse `classes`: {}, {}", line, err))?
+                        .map_err(|err| {
+                            TcpProcessError::Parse(format!(
+                                "fail to parse `classes`: {}, {}",
+                                line, err
+                            ))
+                        })?
                         .1,
                 );
             } else if line.starts_with("ua_os") {
                 ua_os.append(
                     &mut parse_ua_os(line)
-                        .map_err(|err| format_err!("fail to parse `ua_os`: {}, {}", line, err))?
+                        .map_err(|err| {
+                            TcpProcessError::Parse(format!(
+                                "fail to parse `ua_os`: {}, {}",
+                                line, err
+                            ))
+                        })?
                         .1,
                 );
             } else if line.starts_with('[') && line.ends_with(']') {
                 cur_mod = Some(
                     parse_module(line)
-                        .map_err(|err| format_err!("fail to parse `module`: {}, {}", line, err))?
+                        .map_err(|err| {
+                            TcpProcessError::Parse(format!(
+                                "fail to parse `module`: {}, {}",
+                                line, err
+                            ))
+                        })?
                         .1,
                 );
             } else if let Some((module, direction)) = cur_mod.as_ref() {
-                let (_, (name, value)) = parse_named_value(line)
-                    .map_err(|err| format_err!("fail to parse named value: {}, {}", line, err))?;
+                let (_, (name, value)) = parse_named_value(line).map_err(|err| {
+                    TcpProcessError::Parse(format!("fail to parse named value: {}, {}", line, err))
+                })?;
 
                 match name {
                     "label" if module == "mtu" => {
@@ -71,18 +87,29 @@ impl FromStr for Database {
                     }
                     "sig" if module == "mtu" => {
                         if let Some((label, values)) = mtu.last_mut() {
-                            let sig = value.parse()?;
+                            let sig = value.parse::<u16>().map_err(|err| {
+                                TcpProcessError::Parse(format!(
+                                    "fail to parse `mtu` value: {}, {}",
+                                    value, err
+                                ))
+                            })?;
 
                             trace!("`{}` MTU : {}", label, sig);
 
                             values.push(sig);
                         } else {
-                            bail!("`mtu` value without `label`: {}", value);
+                            return Err(TcpProcessError::Parse(format!(
+                                "`mtu` value without `label`: {}",
+                                value
+                            )));
                         }
                     }
                     "label" => {
                         let (_, label) = parse_label(value).map_err(|err| {
-                            format_err!("fail to parse `label`: {}, {}", value, err)
+                            TcpProcessError::Parse(format!(
+                                "fail to parse `label`: {}, {}",
+                                value, err
+                            ))
                         })?;
 
                         match (module.as_str(), direction.as_ref().map(|s| s.as_ref())) {
@@ -104,7 +131,10 @@ impl FromStr for Database {
 
                                 values.push(sig);
                             } else {
-                                bail!("tcp signature without `label`: {}", value)
+                                return Err(TcpProcessError::Parse(format!(
+                                    "tcp signature without `label`: {}",
+                                    value
+                                )));
                             }
                         }
                         ("tcp", Some("response")) => {
@@ -115,7 +145,10 @@ impl FromStr for Database {
 
                                 values.push(sig);
                             } else {
-                                bail!("tcp signature without `label`: {}", value)
+                                return Err(TcpProcessError::Parse(format!(
+                                    "tcp signature without `label`: {}",
+                                    value
+                                )));
                             }
                         }
                         ("http", Some("request")) => {
@@ -126,7 +159,10 @@ impl FromStr for Database {
 
                                 values.push(sig);
                             } else {
-                                bail!("http signature without `label`: {}", value)
+                                return Err(TcpProcessError::Parse(format!(
+                                    "http signature without `label`: {}",
+                                    value
+                                )));
                             }
                         }
                         ("http", Some("response")) => {
@@ -137,7 +173,10 @@ impl FromStr for Database {
 
                                 values.push(sig);
                             } else {
-                                bail!("http signature without `label`: {}", value)
+                                return Err(TcpProcessError::Parse(format!(
+                                    "http signature without `label`: {}",
+                                    value
+                                )));
                             }
                         }
                         _ => {
@@ -150,7 +189,10 @@ impl FromStr for Database {
                     }
                 }
             } else {
-                bail!("unexpected line outside the module: {}", line);
+                return Err(TcpProcessError::Parse(format!(
+                    "unexpected line outside the module: {}",
+                    line
+                )));
             }
         }
 
@@ -169,19 +211,24 @@ impl FromStr for Database {
 macro_rules! impl_from_str {
     ($ty:ty, $parse:ident) => {
         impl FromStr for $ty {
-            type Err = Error;
+            type Err = TcpProcessError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 let (remaining, res) = $parse(s).map_err(|err| {
-                    format_err!("parse {} failed: {}, {}", stringify!($ty), s, err)
+                    TcpProcessError::Parse(format!(
+                        "parse {} failed: {}, {}",
+                        stringify!($ty),
+                        s,
+                        err
+                    ))
                 })?;
 
                 if !remaining.is_empty() {
-                    Err(format_err!(
+                    Err(TcpProcessError::Parse(format!(
                         "parse {} failed, remaining: {}",
                         stringify!($ty),
                         remaining
-                    ))
+                    )))
                 } else {
                     Ok(res)
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,47 @@
 use pnet::packet::ethernet::EtherType;
 use thiserror::Error;
 
+/// Error handling during TCP processing and Database parsing.
 #[derive(Error, Debug)]
 pub enum TcpProcessError {
+    /// An error occurred while parsing data.
+    ///
+    /// This variant is used when a parsing operation fails.
+    /// The associated string provides additional context about the error.
     #[error("Parse error: {0}")]
     Parse(String),
+
+    /// An unsupported protocol was encountered.
+    ///
+    /// This variant is used when a protocol is not supported by the application.
+    /// The associated string specifies the unsupported protocol.
     #[error("Unsupported protocol: {0}")]
     UnsupportedProtocol(String),
+
+    /// Invalid TCP flags were detected.
+    ///
+    /// This variant is used when TCP flags are invalid or unexpected.
+    /// The associated value provides the invalid flags.
     #[error("Invalid TCP flags: {0}")]
     InvalidTcpFlags(u8),
+
+    /// An invalid package was encountered.
+    ///
+    /// This variant is used when a package is deemed invalid.
+    /// The associated string provides details about the invalid package.
     #[error("Invalid package: {0}")]
     UnexpectedPackage(String),
+
+    /// An unsupported Ethernet type was encountered.
+    ///
+    /// This variant is used when an Ethernet type is not supported.
+    /// The associated value specifies the unsupported Ethernet type.
     #[error("Unsupported ethernet type: {0}")]
     UnsupportedEthernetType(EtherType),
+
+    /// An unknown error occurred.
+    ///
+    /// This variant is used as a catch-all for errors that do not fit other categories.
     #[error("Unknown error")]
     Unknown,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use pnet::packet::ethernet::EtherType;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum TcpProcessError {
+    #[error("Parse error: {0}")]
+    Parse(String),
+    #[error("Unsupported protocol: {0}")]
+    UnsupportedProtocol(String),
+    #[error("Invalid TCP flags: {0}")]
+    InvalidTcpFlags(u8),
+    #[error("Invalid package: {0}")]
+    UnexpectedPackage(String),
+    #[error("Unsupported ethernet type: {0}")]
+    UnsupportedEthernetType(EtherType),
+    #[error("Unknown error")]
+    Unknown,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 /// Error handling during TCP processing and Database parsing.
 #[derive(Error, Debug)]
-pub enum TcpProcessError {
+pub enum PassiveTcpError {
     /// An error occurred while parsing data.
     ///
     /// This variant is used when a parsing operation fails.

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,5 @@
 use crate::db::Label;
-use log::debug;
+use tracing::debug;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Signature {

--- a/src/http_process.rs
+++ b/src/http_process.rs
@@ -2,7 +2,6 @@ use crate::db::Label;
 use crate::error::TcpProcessError;
 use crate::{http, http_languages};
 use httparse::{Request, Response, EMPTY_HEADER};
-use log::debug;
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::ipv4::Ipv4Packet;
 use pnet::packet::ipv6::Ipv6Packet;
@@ -10,6 +9,7 @@ use pnet::packet::tcp::TcpPacket;
 use pnet::packet::Packet;
 use std::net::IpAddr;
 use std::time::Duration;
+use tracing::debug;
 use ttl_cache::TtlCache;
 
 /// Maximum number of HTTP headers

--- a/src/http_process.rs
+++ b/src/http_process.rs
@@ -1,5 +1,5 @@
 use crate::db::Label;
-use crate::error::TcpProcessError;
+use crate::error::PassiveTcpError;
 use crate::{http, http_languages};
 use httparse::{Request, Response, EMPTY_HEADER};
 use pnet::packet::ip::IpNextHeaderProtocols;
@@ -75,9 +75,9 @@ impl TcpFlow {
 pub fn process_http_ipv4(
     packet: &Ipv4Packet,
     cache: &mut TtlCache<FlowKey, TcpFlow>,
-) -> Result<ObservableHttpPackage, TcpProcessError> {
+) -> Result<ObservableHttpPackage, PassiveTcpError> {
     if packet.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
-        return Err(TcpProcessError::UnsupportedProtocol("IPv4".to_string()));
+        return Err(PassiveTcpError::UnsupportedProtocol("IPv4".to_string()));
     }
     if let Some(tcp) = TcpPacket::new(packet.payload()) {
         process_tcp_packet(
@@ -97,9 +97,9 @@ pub fn process_http_ipv4(
 pub fn process_http_ipv6(
     packet: &Ipv6Packet,
     cache: &mut TtlCache<FlowKey, TcpFlow>,
-) -> Result<ObservableHttpPackage, TcpProcessError> {
+) -> Result<ObservableHttpPackage, PassiveTcpError> {
     if packet.get_next_header() != IpNextHeaderProtocols::Tcp {
-        return Err(TcpProcessError::UnsupportedProtocol("IPv6".to_string()));
+        return Err(PassiveTcpError::UnsupportedProtocol("IPv6".to_string()));
     }
     if let Some(tcp) = TcpPacket::new(packet.payload()) {
         process_tcp_packet(
@@ -121,7 +121,7 @@ fn process_tcp_packet(
     tcp: TcpPacket,
     src_ip: IpAddr,
     dst_ip: IpAddr,
-) -> Result<ObservableHttpPackage, TcpProcessError> {
+) -> Result<ObservableHttpPackage, PassiveTcpError> {
     let src_port: u16 = tcp.get_source();
     let dst_port: u16 = tcp.get_destination();
     let mut observable_http_package = ObservableHttpPackage {
@@ -185,7 +185,7 @@ fn process_tcp_packet(
     Ok(observable_http_package)
 }
 
-fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, TcpProcessError> {
+fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, PassiveTcpError> {
     let mut headers = [EMPTY_HEADER; HTTP_MAX_HDRS];
     let mut req = Request::new(&mut headers);
 
@@ -222,7 +222,7 @@ fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, TcpP
                 "Failed to parse HTTP request with Data: {:?}. Error: {}",
                 data, e
             );
-            Err(TcpProcessError::Parse(format!(
+            Err(PassiveTcpError::Parse(format!(
                 "Failed to parse HTTP request: {}",
                 e
             )))
@@ -230,7 +230,7 @@ fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, TcpP
     }
 }
 
-fn parse_http_response(data: &[u8]) -> Result<Option<ObservableHttpResponse>, TcpProcessError> {
+fn parse_http_response(data: &[u8]) -> Result<Option<ObservableHttpResponse>, PassiveTcpError> {
     let mut headers = [EMPTY_HEADER; HTTP_MAX_HDRS];
     let mut res = Response::new(&mut headers);
 
@@ -261,7 +261,7 @@ fn parse_http_response(data: &[u8]) -> Result<Option<ObservableHttpResponse>, Tc
                 "Failed to parse HTTP response with Data: {:?}. Error: {}",
                 data, e
             );
-            Err(TcpProcessError::Parse(format!(
+            Err(PassiveTcpError::Parse(format!(
                 "Failed to parse HTTP response: {}",
                 e
             )))

--- a/src/http_process.rs
+++ b/src/http_process.rs
@@ -1,6 +1,6 @@
 use crate::db::Label;
+use crate::error::TcpProcessError;
 use crate::{http, http_languages};
-use failure::{bail, Error};
 use httparse::{Request, Response, EMPTY_HEADER};
 use log::debug;
 use pnet::packet::ip::IpNextHeaderProtocols;
@@ -75,9 +75,9 @@ impl TcpFlow {
 pub fn process_http_ipv4(
     packet: &Ipv4Packet,
     cache: &mut TtlCache<FlowKey, TcpFlow>,
-) -> Result<ObservableHttpPackage, Error> {
+) -> Result<ObservableHttpPackage, TcpProcessError> {
     if packet.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
-        bail!("unsupported IPv4 protocol")
+        return Err(TcpProcessError::UnsupportedProtocol("IPv4".to_string()));
     }
     if let Some(tcp) = TcpPacket::new(packet.payload()) {
         process_tcp_packet(
@@ -97,9 +97,9 @@ pub fn process_http_ipv4(
 pub fn process_http_ipv6(
     packet: &Ipv6Packet,
     cache: &mut TtlCache<FlowKey, TcpFlow>,
-) -> Result<ObservableHttpPackage, Error> {
+) -> Result<ObservableHttpPackage, TcpProcessError> {
     if packet.get_next_header() != IpNextHeaderProtocols::Tcp {
-        bail!("unsupported IPv6 protocol")
+        return Err(TcpProcessError::UnsupportedProtocol("IPv6".to_string()));
     }
     if let Some(tcp) = TcpPacket::new(packet.payload()) {
         process_tcp_packet(
@@ -121,7 +121,7 @@ fn process_tcp_packet(
     tcp: TcpPacket,
     src_ip: IpAddr,
     dst_ip: IpAddr,
-) -> Result<ObservableHttpPackage, Error> {
+) -> Result<ObservableHttpPackage, TcpProcessError> {
     let src_port: u16 = tcp.get_source();
     let dst_port: u16 = tcp.get_destination();
     let mut observable_http_package = ObservableHttpPackage {
@@ -185,7 +185,7 @@ fn process_tcp_packet(
     Ok(observable_http_package)
 }
 
-fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, Error> {
+fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, TcpProcessError> {
     let mut headers = [EMPTY_HEADER; HTTP_MAX_HDRS];
     let mut req = Request::new(&mut headers);
 
@@ -222,7 +222,7 @@ fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, Erro
                 "Failed to parse HTTP request with Data: {:?}. Error: {}",
                 data, e
             );
-            Err(failure::err_msg(format!(
+            Err(TcpProcessError::Parse(format!(
                 "Failed to parse HTTP request: {}",
                 e
             )))
@@ -230,7 +230,7 @@ fn parse_http_request(data: &[u8]) -> Result<Option<ObservableHttpRequest>, Erro
     }
 }
 
-fn parse_http_response(data: &[u8]) -> Result<Option<ObservableHttpResponse>, Error> {
+fn parse_http_response(data: &[u8]) -> Result<Option<ObservableHttpResponse>, TcpProcessError> {
     let mut headers = [EMPTY_HEADER; HTTP_MAX_HDRS];
     let mut res = Response::new(&mut headers);
 
@@ -261,7 +261,7 @@ fn parse_http_response(data: &[u8]) -> Result<Option<ObservableHttpResponse>, Er
                 "Failed to parse HTTP response with Data: {:?}. Error: {}",
                 data, e
             );
-            Err(failure::err_msg(format!(
+            Err(TcpProcessError::Parse(format!(
                 "Failed to parse HTTP response: {}",
                 e
             )))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ use crate::p0f_output::{
 use crate::process::ObservablePackage;
 use crate::signature_matcher::SignatureMatcher;
 use crate::uptime::{Connection, SynData};
-use log::{debug, error};
 use p0f_output::BrowserQualityMatched;
 use p0f_output::OSQualityMatched;
 use p0f_output::WebServerQualityMatched;
@@ -34,6 +33,7 @@ use pnet::datalink;
 use pnet::datalink::Config;
 use std::sync::mpsc::Sender;
 pub use tcp::Ttl;
+use tracing::{debug, error};
 use ttl_cache::TtlCache;
 
 pub struct P0f<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod db;
 mod db_parse;
 mod display;
+mod error;
 mod http;
 mod http_languages;
 mod http_process;

--- a/src/mtu.rs
+++ b/src/mtu.rs
@@ -1,6 +1,6 @@
-use log::debug;
 use pnet::packet::tcp::TcpFlags::SYN;
 use pnet::packet::tcp::TcpPacket;
+use tracing::debug;
 
 pub struct ObservableMtu {
     pub value: u16,

--- a/src/process.rs
+++ b/src/process.rs
@@ -57,12 +57,12 @@ impl ObservablePackage {
 }
 
 fn visit_ethernet(
-    ethertype: EtherType,
+    ether_type: EtherType,
     tcp_cache: &mut TtlCache<Connection, SynData>,
     http_cache: &mut TtlCache<FlowKey, TcpFlow>,
     payload: &[u8],
 ) -> Result<ObservablePackage, TcpProcessError> {
-    match ethertype {
+    match ether_type {
         EtherTypes::Vlan => VlanPacket::new(payload)
             .ok_or_else(|| TcpProcessError::UnexpectedPackage("vlan packet too short".to_string()))
             .and_then(|packet| visit_vlan(tcp_cache, http_cache, packet)),

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,3 +1,4 @@
+use crate::error::TcpProcessError;
 use crate::http_process::{
     FlowKey, ObservableHttpPackage, ObservableHttpRequest, ObservableHttpResponse, TcpFlow,
 };
@@ -6,7 +7,6 @@ use crate::tcp_process::{ObservableTCPPackage, ObservableTcp};
 use crate::uptime::ObservableUptime;
 use crate::uptime::{Connection, SynData};
 use crate::{http_process, tcp_process};
-use failure::{bail, err_msg, Error};
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::{
     ethernet::{EtherType, EtherTypes, EthernetPacket},
@@ -40,9 +40,11 @@ impl ObservablePackage {
         packet: &[u8],
         tcp_cache: &mut TtlCache<Connection, SynData>,
         http_cache: &mut TtlCache<FlowKey, TcpFlow>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, TcpProcessError> {
         EthernetPacket::new(packet)
-            .ok_or_else(|| err_msg("ethernet packet too short"))
+            .ok_or_else(|| {
+                TcpProcessError::UnexpectedPackage("ethernet packet too short".to_string())
+            })
             .and_then(|packet| {
                 visit_ethernet(
                     packet.get_ethertype(),
@@ -59,21 +61,21 @@ fn visit_ethernet(
     tcp_cache: &mut TtlCache<Connection, SynData>,
     http_cache: &mut TtlCache<FlowKey, TcpFlow>,
     payload: &[u8],
-) -> Result<ObservablePackage, Error> {
+) -> Result<ObservablePackage, TcpProcessError> {
     match ethertype {
         EtherTypes::Vlan => VlanPacket::new(payload)
-            .ok_or_else(|| err_msg("vlan packet too short"))
+            .ok_or_else(|| TcpProcessError::UnexpectedPackage("vlan packet too short".to_string()))
             .and_then(|packet| visit_vlan(tcp_cache, http_cache, packet)),
 
         EtherTypes::Ipv4 => Ipv4Packet::new(payload)
-            .ok_or_else(|| err_msg("ipv4 packet too short"))
+            .ok_or_else(|| TcpProcessError::UnexpectedPackage("ipv4 packet too short".to_string()))
             .and_then(|packet| process_ipv4(tcp_cache, http_cache, packet)),
 
         EtherTypes::Ipv6 => Ipv6Packet::new(payload)
-            .ok_or_else(|| err_msg("ipv6 packet too short"))
+            .ok_or_else(|| TcpProcessError::UnexpectedPackage("ipv6 packet too short".to_string()))
             .and_then(|packet| process_ipv6(tcp_cache, http_cache, packet)),
 
-        ty => bail!("unsupported ethernet type: {}", ty),
+        ty => return Err(TcpProcessError::UnsupportedEthernetType(ty)),
     }
 }
 
@@ -81,7 +83,7 @@ fn visit_vlan(
     tcp_cache: &mut TtlCache<Connection, SynData>,
     http_cache: &mut TtlCache<FlowKey, TcpFlow>,
     packet: VlanPacket,
-) -> Result<ObservablePackage, Error> {
+) -> Result<ObservablePackage, TcpProcessError> {
     visit_ethernet(
         packet.get_ethertype(),
         tcp_cache,
@@ -94,12 +96,12 @@ pub fn process_ipv4(
     tcp_cache: &mut TtlCache<Connection, SynData>,
     http_cache: &mut TtlCache<FlowKey, TcpFlow>,
     packet: Ipv4Packet,
-) -> Result<ObservablePackage, Error> {
+) -> Result<ObservablePackage, TcpProcessError> {
     if packet.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
-        bail!(
+        return Err(TcpProcessError::UnsupportedProtocol(format!(
             "unsupported IPv4 packet with non-TCP payload: {}",
             packet.get_next_level_protocol()
-        );
+        )));
     }
 
     let packet_data = packet.packet().to_vec();
@@ -127,12 +129,12 @@ pub fn process_ipv6(
     tcp_cache: &mut TtlCache<Connection, SynData>,
     http_cache: &mut TtlCache<FlowKey, TcpFlow>,
     packet: Ipv6Packet,
-) -> Result<ObservablePackage, Error> {
+) -> Result<ObservablePackage, TcpProcessError> {
     if packet.get_next_header() != IpNextHeaderProtocols::Tcp {
-        bail!(
-            "unsuppport IPv6 packet with non-TCP payload: {}",
+        return Err(TcpProcessError::UnsupportedProtocol(format!(
+            "IPv6 packet with non-TCP payload: {}",
             packet.get_next_header()
-        );
+        )));
     }
 
     let packet_data = packet.packet().to_vec();
@@ -157,9 +159,9 @@ pub fn process_ipv6(
 }
 
 fn handle_http_tcp_responses(
-    http_response: Result<ObservableHttpPackage, Error>,
-    tcp_response: Result<ObservableTCPPackage, Error>,
-) -> Result<ObservablePackage, Error> {
+    http_response: Result<ObservableHttpPackage, TcpProcessError>,
+    tcp_response: Result<ObservableTCPPackage, TcpProcessError>,
+) -> Result<ObservablePackage, TcpProcessError> {
     match (http_response, tcp_response) {
         (Ok(http_package), Ok(tcp_package)) => Ok(ObservablePackage {
             source: tcp_package.source,

--- a/src/process.rs
+++ b/src/process.rs
@@ -75,7 +75,7 @@ fn visit_ethernet(
             .ok_or_else(|| TcpProcessError::UnexpectedPackage("ipv6 packet too short".to_string()))
             .and_then(|packet| process_ipv6(tcp_cache, http_cache, packet)),
 
-        ty => return Err(TcpProcessError::UnsupportedEthernetType(ty)),
+        ty => Err(TcpProcessError::UnsupportedEthernetType(ty)),
     }
 }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,5 +1,5 @@
 use crate::db::Label;
-use log::debug;
+use tracing::debug;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Signature {

--- a/src/tcp_process.rs
+++ b/src/tcp_process.rs
@@ -1,3 +1,4 @@
+use crate::error::TcpProcessError;
 use crate::ip_options::IpOptions;
 use crate::mtu::ObservableMtu;
 use crate::process::IpPort;
@@ -7,7 +8,6 @@ use crate::uptime::{check_ts_tcp, ObservableUptime};
 use crate::uptime::{Connection, SynData};
 use crate::window_size::detect_win_multiplicator;
 use crate::{mtu, ttl};
-use failure::{bail, err_msg, Error};
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::{
     ipv4::{Ipv4Flags, Ipv4Packet},
@@ -61,15 +61,15 @@ fn is_valid(tcp_flags: u8, tcp_type: u8) -> bool {
 pub fn process_tcp_ipv4(
     cache: &mut TtlCache<Connection, SynData>,
     packet: &Ipv4Packet,
-) -> Result<ObservableTCPPackage, Error> {
+) -> Result<ObservableTCPPackage, TcpProcessError> {
     if packet.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
-        bail!("unsupported IPv4 protocol")
+        return Err(TcpProcessError::UnsupportedProtocol("IPv4".to_string()));
     }
 
     if packet.get_fragment_offset() > 0
         || (packet.get_flags() & Ipv4Flags::MoreFragments) == Ipv4Flags::MoreFragments
     {
-        bail!("unsupported IPv4 fragment")
+        return Err(TcpProcessError::UnexpectedPackage("IPv4".to_string()));
     }
 
     let version = IpVersion::V4;
@@ -104,7 +104,7 @@ pub fn process_tcp_ipv4(
     let ip_package_header_length: u8 = packet.get_header_length();
 
     TcpPacket::new(tcp_payload)
-        .ok_or_else(|| err_msg("TCP packet too short"))
+        .ok_or_else(|| TcpProcessError::UnexpectedPackage("TCP packet too short".to_string()))
         .and_then(|tcp_packet| {
             visit_tcp(
                 cache,
@@ -123,9 +123,9 @@ pub fn process_tcp_ipv4(
 pub fn process_tcp_ipv6(
     cache: &mut TtlCache<Connection, SynData>,
     packet: &Ipv6Packet,
-) -> Result<ObservableTCPPackage, Error> {
+) -> Result<ObservableTCPPackage, TcpProcessError> {
     if packet.get_next_header() != IpNextHeaderProtocols::Tcp {
-        bail!("unsupported IPv6 protocol")
+        return Err(TcpProcessError::UnsupportedProtocol("IPv6".to_string()));
     }
     let version = IpVersion::V6;
     let ttl_observed: u8 = packet.get_hop_limit();
@@ -146,7 +146,7 @@ pub fn process_tcp_ipv6(
     let ip_package_header_length: u8 = 40; //IPv6 header is always 40 bytes
 
     TcpPacket::new(packet.payload())
-        .ok_or_else(|| err_msg("TCP packet too short"))
+        .ok_or_else(|| TcpProcessError::UnexpectedPackage("TCP packet too short".to_string()))
         .and_then(|tcp_packet| {
             visit_tcp(
                 cache,
@@ -173,7 +173,7 @@ fn visit_tcp(
     mut quirks: Vec<Quirk>,
     source_ip: IpAddr,
     destination_ip: IpAddr,
-) -> Result<ObservableTCPPackage, Error> {
+) -> Result<ObservableTCPPackage, TcpProcessError> {
     use TcpFlags::*;
 
     let source_port = tcp.get_source();
@@ -201,7 +201,7 @@ fn visit_tcp(
     }
     let tcp_type: u8 = flags & (SYN | ACK | FIN | RST);
     if !is_valid(flags, tcp_type) {
-        bail!("invalid TCP flags: {}", flags);
+        return Err(TcpProcessError::InvalidTcpFlags(flags));
     }
 
     if (flags & (ECE | CWR)) != 0 {
@@ -292,19 +292,35 @@ fn visit_tcp(
             TIMESTAMPS => {
                 olayout.push(TcpOption::TS);
 
-                if data.len() >= 4 && u32::from_ne_bytes(data[..4].try_into()?) == 0 {
-                    quirks.push(Quirk::OwnTimestampZero);
+                if data.len() >= 4 {
+                    let ts_val_bytes: [u8; 4] = data[..4].try_into().map_err(|_| {
+                        TcpProcessError::Parse(
+                            "Failed to convert slice to array for timestamp value".to_string(),
+                        )
+                    })?;
+                    if u32::from_ne_bytes(ts_val_bytes) == 0 {
+                        quirks.push(Quirk::OwnTimestampZero);
+                    }
                 }
 
-                if data.len() >= 8
-                    && tcp_type == SYN
-                    && u32::from_ne_bytes(data[4..8].try_into()?) != 0
-                {
-                    quirks.push(Quirk::PeerTimestampNonZero);
+                if data.len() >= 8 && tcp_type == SYN {
+                    let ts_peer_bytes: [u8; 4] = data[4..8].try_into().map_err(|_| {
+                        TcpProcessError::Parse(
+                            "Failed to convert slice to array for peer timestamp value".to_string(),
+                        )
+                    })?;
+                    if u32::from_ne_bytes(ts_peer_bytes) != 0 {
+                        quirks.push(Quirk::PeerTimestampNonZero);
+                    }
                 }
 
                 if data.len() >= 8 {
-                    let ts_val: u32 = u32::from_ne_bytes(data[..4].try_into()?);
+                    let ts_val_bytes: [u8; 4] = data[..4].try_into().map_err(|_| {
+                        TcpProcessError::Parse(
+                            "Failed to convert slice to array for timestamp value".to_string(),
+                        )
+                    })?;
+                    let ts_val: u32 = u32::from_ne_bytes(ts_val_bytes);
                     let connection: Connection = Connection {
                         src_ip: source_ip,
                         src_port: tcp.get_source(),

--- a/src/uptime.rs
+++ b/src/uptime.rs
@@ -1,6 +1,6 @@
-use log::debug;
 use std::net::IpAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::debug;
 use ttl_cache::TtlCache;
 
 // const MIN_TWAIT: u64 = 0;


### PR DESCRIPTION
The `failure` lib is deprecated. Refactor error types to use `thiserror` for custom errors handler.
