### PR TITLE
fix ParseIntError for string value (Unknown)

### DIFF
--- a/src/fingerprint_result.rs
+++ b/src/fingerprint_result.rs
@@ -108,7 +108,9 @@ impl fmt::Display for SynTCPOutput {
             }),
             match self.sig.ittl {
                 Ttl::Distance(_, distance) => distance,
-                _ => "Unknown".parse().unwrap(),
+                Ttl::Bad(value) => value,
+                Ttl::Value(value) => value,
+                Ttl::Guess(value) => value,
             },
             self.os_matched
                 .as_ref()


### PR DESCRIPTION
# Pull Request Template

## Description

Hi!

I tried running the example program and every now and then it crashes at this line:

https://github.com/biandratti/passivetcp-rs/blob/205b8fa5c33f0e2e122c5136ca79510e8639cb41/src/fingerprint_result.rs#L111

This is because the string `Unknown` cannot be converted to `u8` (the `distance` type). So I replace it with the same code in `SynAckTCPOutput`:

https://github.com/biandratti/passivetcp-rs/blob/205b8fa5c33f0e2e122c5136ca79510e8639cb41/src/fingerprint_result.rs#L162-L167

## Type of change:

Please select the appropriate tags in the PR if necessary.

# Motivation

Keeping thing up-to-date

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce, and the Operative System used.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Select the appropriate tags in the PR if necessary.
