### PR TITLE
Compare headers fixed

### DIFF
--- a/src/observable_http_signals_matching.rs
+++ b/src/observable_http_signals_matching.rs
@@ -4,20 +4,6 @@ use crate::http;
 use crate::http::{Header, HttpMatchQuality, Version};
 use crate::observable_signals::{ObservableHttpRequest, ObservableHttpResponse};
 
-// Helper function to compare observed headers with signature headers
-// 1. If the header name is different, return false
-// 2. If the header is optional, return true
-// 3. If the header is not optional, return true if the value is the same
-fn headers_match(observed: &Header, signature: &Header) -> bool {
-    if observed.name != signature.name {
-        return false;
-    }
-    if signature.optional {
-        return true;
-    }
-    observed.value == signature.value
-}
-
 trait HttpDistance {
     fn get_version(&self) -> Version;
     fn get_horder(&self) -> &[Header];
@@ -32,31 +18,76 @@ trait HttpDistance {
         }
     }
 
-    // Compare two header vectors and return the number of matching headers.
-    // The quality is based on the number of matching headers.
+    // Compare two header vectors respecting order and allowing optional header skips
+    //
+    // This function implements a sophisticated two-pointer algorithm to compare HTTP headers
+    // from observed traffic against database signatures while preserving order and handling
+    // optional headers that may be missing from the observed traffic.
+    //
+    // Algorithm Overview:
+    // 1. Use two pointers to traverse both lists simultaneously
+    // 2. When headers match perfectly (name + value), advance both pointers
+    // 3. When names match but values differ, count as error only if header is required
+    // 4. When names differ, skip optional signature headers or count required ones as errors
+    // 5. Handle remaining headers at the end of either list
+    //
+    // Parameters:
+    // - observed: Headers from actual HTTP traffic (never marked as optional)
+    // - signature: Headers from database signature (may have optional headers marked with ?)
+    //
+    // Returns:
+    // - Some(score) based on error count converted to quality score
+    // - None if too many errors (unmatchable)
     fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32> {
-        let len_a = observed.len();
-        let len_b = signature.len();
-        let min_len = len_a.min(len_b);
-        let max_len = len_a.max(len_b);
+        let mut obs_idx = 0; // Index pointer for observed headers
+        let mut sig_idx = 0; // Index pointer for signature headers
+        let mut errors = 0; // Running count of matching errors
 
-        let mut actual_matches = 0;
-        for i in 0..min_len {
-            if headers_match(&observed[i], &signature[i]) {
-                actual_matches += 1;
+        while obs_idx < observed.len() && sig_idx < signature.len() {
+            let obs_header = &observed[obs_idx];
+            let sig_header = &signature[sig_idx];
+
+            // Check if headers match (name and value)
+            if obs_header.name == sig_header.name && obs_header.value == sig_header.value {
+                // Perfect match - advance both pointers
+                obs_idx += 1;
+                sig_idx += 1;
+            } else if obs_header.name == sig_header.name {
+                if !sig_header.optional {
+                    errors += 1;
+                }
+                obs_idx += 1;
+                sig_idx += 1;
+            } else {
+                if sig_header.optional {
+                    sig_idx += 1;
+                } else {
+                    errors += 1;
+                    sig_idx += 1;
+                }
             }
         }
 
-        // Calculate errors based on the difference between the length of the longer list
-        // and the number of actual matches in the common part.
-        let errors = max_len - actual_matches;
+        while obs_idx < observed.len() {
+            errors += 1;
+            obs_idx += 1;
+        }
 
+        while sig_idx < signature.len() {
+            if !signature[sig_idx].optional {
+                errors += 1;
+            }
+            sig_idx += 1;
+        }
+
+        // Convert error count to quality score using predefined ranges
+        // Lower error counts indicate better matches
         match errors {
-            0..=2 => Some(HttpMatchQuality::High.as_score()),
-            3..=5 => Some(HttpMatchQuality::Medium.as_score()),
-            6..=8 => Some(HttpMatchQuality::Low.as_score()),
-            9..=11 => Some(HttpMatchQuality::Bad.as_score()),
-            _ => None,
+            0..=2 => Some(HttpMatchQuality::High.as_score()), // 0-2 errors: High quality match
+            3..=5 => Some(HttpMatchQuality::Medium.as_score()), // 3-5 errors: Medium quality match
+            6..=8 => Some(HttpMatchQuality::Low.as_score()),  // 6-8 errors: Low quality match
+            9..=11 => Some(HttpMatchQuality::Bad.as_score()), // 9-11 errors: Bad but still usable match
+            _ => None, // 12+ errors: Too many differences, not a viable match
         }
     }
 
@@ -257,6 +288,298 @@ mod tests {
             result,
             Some(HttpMatchQuality::High.as_score()),
             "Expected Medium quality for 1 error in lists of 10"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_optional_skip_in_middle() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Optional header in middle should be skipped for perfect alignment"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_multiple_optional_skips() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US"),
+            Header::new("Accept-Encoding").optional().with_value("gzip"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Multiple optional headers should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_required_in_middle_causes_error() {
+        // Required header in middle should cause error and misalignment
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"), // Required, missing
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()), // 1 error falls in High range (0-2 errors)
+            "Required header missing should cause 1 error"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_realistic_browser_with_optional_skips() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Accept").with_value("text/html"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Accept").with_value("text/html"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US"), // Optional, missing
+            Header::new("Accept-Encoding").optional().with_value("gzip"), // Optional, missing
+            Header::new("Cookie").optional(),                             // Optional, missing
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Browser should match signature even with optional headers missing"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_missing_optional_header() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US"), // Missing but optional
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Missing optional headers should not cause errors"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_missing_required_header() {
+        let observed = vec![Header::new("Host")];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"), // Missing and NOT optional
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()), // 1 error out of many
+            "Missing required headers should cause errors"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_extra_headers_in_observed() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("X-Custom-Header").with_value("custom"), // Extra header
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()), // 1 error for extra header
+            "Extra headers in observed should cause errors"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_optional_header_at_end() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US"), // Optional, missing
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Missing optional headers at end should not cause errors"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_required_header_at_end() {
+        let observed = vec![Header::new("Host")];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"), // Required, missing
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Missing required headers should cause 1 error"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_observed_vs_signature_with_optional() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Accept").with_value("text/html"),
+            Header::new("Accept-Language").with_value("en-US"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent").with_value("Mozilla/5.0"),
+            Header::new("Accept").with_value("text/html"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US"), // Optional but value must match
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Should match perfectly: all headers match including values for optional headers"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_value_mismatch_not_optional() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("Connection").with_value("close"), // Different value, not optional
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Should have 1 error out of 2 headers"
+        );
+    }
+
+    #[test]
+    fn test_distance_header_realistic_browser_scenario() {
+        let observed = vec![
+            Header::new("Host"),
+            Header::new("User-Agent")
+                .with_value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0"),
+            Header::new("Accept").with_value("text/html,application/xhtml+xml"),
+            Header::new("Accept-Language").with_value("en-US,en;q=0.9"),
+            Header::new("Accept-Encoding").with_value("gzip, deflate"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        // Database signature for Chrome
+        let signature = vec![
+            Header::new("Host"),
+            Header::new("User-Agent")
+                .with_value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0"),
+            Header::new("Accept").with_value("text/html,application/xhtml+xml"),
+            Header::new("Accept-Language")
+                .optional()
+                .with_value("en-US,en;q=0.9"), // Optional but value must match
+            Header::new("Accept-Encoding").with_value("gzip, deflate"),
+            Header::new("Connection").with_value("keep-alive"),
+        ];
+
+        let result =
+            <ObservableHttpRequest as HttpDistance>::distance_header(&observed, &signature);
+        assert_eq!(
+            result,
+            Some(HttpMatchQuality::High.as_score()),
+            "Should match perfectly for realistic Chrome signature with value matching"
         );
     }
 }

--- a/src/observable_http_signals_matching.rs
+++ b/src/observable_http_signals_matching.rs
@@ -58,13 +58,11 @@ trait HttpDistance {
                 }
                 obs_idx += 1;
                 sig_idx += 1;
+            } else if sig_header.optional {
+                sig_idx += 1;
             } else {
-                if sig_header.optional {
-                    sig_idx += 1;
-                } else {
-                    errors += 1;
-                    sig_idx += 1;
-                }
+                errors += 1;
+                sig_idx += 1;
             }
         }
 


### PR DESCRIPTION
Compare headers with the database signatures fixed.
Algorithm added to compare headers in order and skip them when they are optional.
